### PR TITLE
Set "overflow: auto" CSS property on "pre" elements for standalone HTMLs

### DIFF
--- a/lib/Text/Amuse/Compile/Templates.pm
+++ b/lib/Text/Amuse/Compile/Templates.pm
@@ -359,6 +359,11 @@ div#page {
 pre, code {
     font-family: [% IF fonts %]"[% fonts.mono.name %]",[% END %]Consolas, courier, monospace;
 }
+
+pre {
+    overflow: auto;
+}
+
 /* invisibles */
 span.hiddenindex, span.commentmarker, .comment, span.tocprefix, #hitme {
     display: none


### PR DESCRIPTION
Otherwise the whole page of, for example, markup manual, is scrolled horizontally on mobile devices

Fixes issue #17