### PR TITLE
Fix CSS styles for blockquotes in EPUB

### DIFF
--- a/lib/Text/Amuse/Compile/Templates.pm
+++ b/lib/Text/Amuse/Compile/Templates.pm
@@ -348,6 +348,14 @@ a {
    text-decoration: none;
 }
 
+[% IF epub %]
+/* Workaround for CoolReader, which does not seem to have default style for blockquotes. */
+/* These values are taken from https://www.w3schools.com/cssref/css_default_values.asp */
+blockquote {
+   margin: 1em 40px;
+}
+[% END %]
+
 [% IF html %]
 div#page {
    margin:20px;

--- a/lib/Text/Amuse/Compile/Templates.pm
+++ b/lib/Text/Amuse/Compile/Templates.pm
@@ -337,7 +337,6 @@ p.tableofcontentline {
 blockquote > p, li > p {
    margin-top: 0.5em;
    text-indent: 0em;
-   text-align: justify;
 }
 
 a {

--- a/lib/Text/Amuse/Compile/Templates.pm
+++ b/lib/Text/Amuse/Compile/Templates.pm
@@ -334,11 +334,6 @@ p.tableofcontentline {
    margin: 0;
 }
 
-blockquote > p, li > p {
-   margin-top: 0.5em;
-   text-indent: 0em;
-}
-
 a {
    color:#000000;
    text-decoration: underline;

--- a/lib/Text/Amuse/Compile/Templates.pm
+++ b/lib/Text/Amuse/Compile/Templates.pm
@@ -324,7 +324,7 @@ div#thework {
     margin-top: 3em;
 }
 
-div#thework > p {
+div#thework p {
    margin: 0;
    text-indent: 1em;
    text-align: justify;


### PR DESCRIPTION
The image shows the results for the last commit (second row) and the commit just before the last one (first row):
![cmp2](https://user-images.githubusercontent.com/18373967/54883316-a2fda380-4e5c-11e9-8b39-259cbc13ccf3.png)

Left column is FBReader engine ([Book Reader](https://www.f-droid.org/en/packages/com.github.axet.bookreader/)), right column is Cool Reader.

I did not take screenshots of the current state, but basically the problem is that in Cool Reader blockquotes look the same as the rest of the text.

As a summary, I
 - applied paragraph styles to all paragraphs below `div#thework`, not just direct descendants
 - removed special styles for `blockquote > p` and `li > p` (which made paragraphs look indented *less* than the rest of the text when I added margins for blockquote and added more space between paragraphs in blockquotes than in the rest of the text)
 - applied default HTML styles for blockquotes as a workaround for Cool Reader which does not seem to apply any styles by default.