### PR TITLE
Increase specificity of div.center and div.right CSS rules

### DIFF
--- a/lib/Text/Amuse/Compile/Templates.pm
+++ b/lib/Text/Amuse/Compile/Templates.pm
@@ -324,10 +324,20 @@ div#thework {
     margin-top: 3em;
 }
 
-div#thework p {
+div#thework > p {
    margin: 0;
    text-indent: 1em;
    text-align: justify;
+}
+
+/*
+ * Separate paragraphs inside blockquotes and lists
+ * with margins
+ * instead of indentation to emulate LaTeX layout.
+ */
+div#thework blockquote > p, li > p {
+  margin-top: 0.5em;
+  text-indent: 0;
 }
 
 p.tableofcontentline {

--- a/lib/Text/Amuse/Compile/Templates.pm
+++ b/lib/Text/Amuse/Compile/Templates.pm
@@ -500,11 +500,11 @@ div.caption {
     text-align: center;
 }
 
-div.center {
+div#thework div.center p {
     text-align: center;
 }
 
-div.right {
+div#thework div.right p {
     text-align: right;
 }
 


### PR DESCRIPTION
Otherwise "div#thework p" overrides text alignment.

Bug introduced in #19, see the discussion there.