### PR TITLE
Add default CSS styles for blockquote in EPUB

### DIFF
--- a/lib/Text/Amuse/Compile/Templates.pm
+++ b/lib/Text/Amuse/Compile/Templates.pm
@@ -349,6 +349,19 @@ a {
    text-decoration: none;
 }
 
+[% IF epub %]
+/*
+ * Workaround for Cool Reader, which as of version 3.2.9
+ * does not have default styles for blockquotes defined.
+ *
+ * These values are taken from https://www.w3schools.com/cssref/css_default_values.asp
+ * Firefox 66 uses the same styles by default.
+ */
+blockquote {
+   margin: 1em 40px;
+}
+[% END %]
+
 [% IF html %]
 div#page {
    margin:20px;


### PR DESCRIPTION
This is a commit from the merged and reverted PR #19 with a slightly refined comment.

It is a minimal change that at least makes blockquotes distinguishable in Cool Reader when all styles in the settings are set to "-" which means "inherit". (Android version of Cool Reader allows tweaking all the CSS settings via graphical menu.)

By the way, KOReader does not have this problem because they added some default styles for `blockquote` element, though they are slightly different from the browser defaults:
 - https://github.com/koreader/crengine/commit/0d5dc2d9f7a5d636735d9b43e15479025f2f3f1f
 - https://github.com/koreader/crengine/commit/9050d84a8254d62bc5d250ccf649362fdc20e3fb